### PR TITLE
Breathe Inline fixes

### DIFF
--- a/sphinx_markdown_builder/builder.py
+++ b/sphinx_markdown_builder/builder.py
@@ -94,3 +94,18 @@ class MarkdownBuilder(Builder):
         with io_handler(out_filename):
             with open(out_filename, "w", encoding="utf-8") as file:
                 file.write(self.writer.output)
+    
+    def copy_image_files(self) -> None:
+        if self.images:
+            for key in self.images.keys():
+                copy_asset_file(os.path.join(self.srcdir, key), self.outdir)
+    
+    def write(
+        self,
+        build_docnames,
+        updated_docnames,
+        method: str = 'update',
+    ) -> None:
+        super().write(build_docnames, updated_docnames, method)
+        self.copy_image_files()
+

--- a/sphinx_markdown_builder/builder.py
+++ b/sphinx_markdown_builder/builder.py
@@ -13,6 +13,7 @@ from sphinx.environment import BuildEnvironment
 from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.osutil import ensuredir, os_path
+from sphinx.util.fileutil import copy_asset_file
 
 from sphinx_markdown_builder.translator import MarkdownTranslator
 from sphinx_markdown_builder.writer import MarkdownWriter

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -623,7 +623,14 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
         # Insert anchors if enabled by the config
         if self.config.markdown_anchor_signatures:
             for anchor in node.get("ids", []):
-                self._add_anchor(anchor)
+                # only use v4 cpp anchors
+                if len(anchor) < 6:
+                    self._add_anchor(anchor)
+                elif anchor[0:5] == "_CPPv":
+                    if not (anchor[5:6] in ["2","3"]):
+                        self._add_anchor(anchor)
+                else:
+                    self._add_anchor(anchor)
 
         # We don't want methods to be at the same level as classes,
         # If signature has a non-null class, that's means it is a signature

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -86,6 +86,7 @@ PREDEFINED_ELEMENTS: Dict[str, Union[PushContext, SKIP, None]] = dict(  # pylint
     document=None,
     container=None,
     inline=None,
+    Inline=None,
     definition_list=None,
     definition_list_item=None,
     glossary=None,
@@ -524,6 +525,11 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
     @pushing_context
     def visit_reference(self, node):
         url = self._fetch_ref_uri(node)
+        # if the reference object itself has the url 
+        # (such as for an intra-document heading reference)
+        # use that url instead
+        if ref_id is not None and url == "":
+            url = f"#{ref_id}"
         self._push_context(WrappedContext("[", f"]({url})"))
 
     @pushing_context

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -528,6 +528,7 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
         # if the reference object itself has the url 
         # (such as for an intra-document heading reference)
         # use that url instead
+        ref_id = node.get("refid", None)
         if ref_id is not None and url == "":
             url = f"#{ref_id}"
         self._push_context(WrappedContext("[", f"]({url})"))

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -324,6 +324,7 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
         """Image directive."""
         uri = node["uri"]
         alt = node.attributes.get("alt", "image")
+        self.builder.images[uri] = uri
         # We don't need to add EOL before/after the image.
         # It will be handled by the visit/depart handlers of the paragraph.
         self.add(f"![{alt}]({uri})")


### PR DESCRIPTION
Ran into some complications when trying to use this builder for a document set that was previously hosted in html.  Mostly this was to do with directives generated by the breathe extension for interfacing doxygen with sphinx (I was getting empty headings where function definitions sourced from the C should be), but I also noticed images weren't copying into the document output and some broken links within documents I fixed as well.  

Only tested these changes on my local so further vetting required here