### PR TITLE
Workaround for github-flavored markdown not ignoring newlines within paragraphs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test-diff:
 	@$(SPHINX_BUILD) -M markdown "$(SOURCE_DIR)" "$(BUILD_DIR)/overrides" $(SPHINX_OPTS) $(O) -a \
 			-D markdown_http_base="https://localhost" -D markdown_uri_doc_suffix=".html" \
 			-D markdown_docinfo=1 -D markdown_anchor_sections=1 -D markdown_anchor_signatures=1 \
-			-D autodoc_typehints=signature -D markdown_bullet=-
+			-D autodoc_typehints=signature -D markdown_bullet=- -D markdown_flavor=github
 
 	@# Copy just the files for verification
 	@cp "$(BUILD_DIR)/overrides/markdown/auto-summery.md" "$(BUILD_DIR)/markdown/overrides-auto-summery.md"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can add the following configurations to your `conf.py` file:
 * `markdown_uri_doc_suffix`: If set, all references will link to documents with this suffix.
 * `markdown_file_suffix`: Sets the file extension for generated markdown files (default: `.md`).
 * `markdown_bullet`: Sets the bullet marker.
+* `markdown_flavor`: If set to `github`, output will suit GitHub's flavor of Markdown.
 
 For example, if your `conf.py` file have the following configuration:
 

--- a/sphinx_markdown_builder/__init__.py
+++ b/sphinx_markdown_builder/__init__.py
@@ -20,6 +20,7 @@ def setup(app) -> ExtensionMetadata:
     app.add_config_value("markdown_anchor_signatures", False, "html", bool)
     app.add_config_value("markdown_docinfo", False, "html", bool)
     app.add_config_value("markdown_bullet", "*", "html", str)
+    app.add_config_value("markdown_flavor", "", "html", str)
 
     return {
         "version": __version__,

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -345,6 +345,9 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
     # noinspection PyPep8Naming
     def visit_Text(self, node):  # pylint: disable=invalid-name
         text = node.astext().replace("\r", "")
+        # Replace line breaks with spaces to create single-line paragraphs
+        if self.config.markdown_flavor == "github":
+            text = text.replace("\n", " ")
         if self.status.escape_text:
             text = escape_markdown_chars(text)
         self.add(text)

--- a/tests/expected/overrides-auto-module.md
+++ b/tests/expected/overrides-auto-module.md
@@ -39,8 +39,7 @@ Deprecated since version 3.1: Use `other()` instead.
 
 ### func1(param1: [int](https://docs.python.org/3/library/functions.html#int)) → [int](https://docs.python.org/3/library/functions.html#int)
 
-This is a function with a single parameter.
-Thanks to github.com/remiconnesson.
+This is a function with a single parameter. Thanks to github.com/remiconnesson.
 
 * **Parameters:**
   **param1** – This is a single parameter.

--- a/tests/expected/overrides-auto-summery.md
+++ b/tests/expected/overrides-auto-summery.md
@@ -3,10 +3,7 @@
 <meta name="version" content="0.6.8"/>
 
 <!-- Taken from https://github.com/FabianNiehaus/sphinx-markdown-builder-toctree-test -->
-<!-- Sphinx-Markdown-Builder TocTree Test documentation master file, created by
-sphinx-quickstart on Thu Sep  3 12:25:35 2020.
-You can adapt this file completely to your liking, but it should at least
-contain the root `toctree` directive. -->
+<!-- Sphinx-Markdown-Builder TocTree Test documentation master file, created by sphinx-quickstart on Thu Sep  3 12:25:35 2020. You can adapt this file completely to your liking, but it should at least contain the root `toctree` directive. -->
 
 <a id="welcome-to-sphinx-markdown-builder-toctree-test-s-documentation"></a>
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -34,6 +34,8 @@ SOURCE_FLAGS = [
         "markdown_bullet=-",
         "-D",
         "markdown_file_suffix=.html.md",
+        "-D",
+        "markdown_flavor=github",
         "-j",
         "8",
     ],


### PR DESCRIPTION
I use sphinx-markdown-builder to generate release notes for GitHub
releases.

Unlike CommonMark, GitHub's flavor of Markdown interprets input like
`line1\nline2` as `line1<br/>line2`.

As a workaround, I could write each paragraph in my *.rst sources in
only one line *.rst.  But I'm not sure I want to do that; it would
be surprising to people who work on the *.rst sources because all
other builders (HTML, man, markdown+commonmark) handle this just fine.

Add a workaround to produce a faithful version GitHub-flavored
markdown by joining all multiline paragraphs into a single line.

I'm not aware of significant downsides yet (except that the Markdown
is uglier) but I haven't tested beyond my real-world use.

To be safe, I put it behind a config option, if only to not muddy
the waters as to which dialect of Markdown we are targeting.

Might as well make that option open for extensions, because there
are quite a few flavors:

	$ pandoc --list-input-formats | grep mark -i | paste -sd ,
	commonmark,commonmark_x,markdown,markdown_github,markdown_mmd,markdown_phpextra,markdown_strict
