### PR TITLE
Add tip, caution, danger, error admonitions

### DIFF
--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -334,6 +334,26 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
         """Sphinx hint directive."""
         self._push_box("HINT")
 
+    @pushing_context
+    def visit_tip(self, _node):
+        """Sphinx tip directive."""
+        self._push_box("TIP")
+
+    @pushing_context
+    def visit_caution(self, _node):
+        """Sphinx caution directive."""
+        self._push_box("CAUTION")
+
+    @pushing_context
+    def visit_danger(self, _node):
+        """Sphinx danger directive."""
+        self._push_box("DANGER")
+
+    @pushing_context
+    def visit_error(self, _node):
+        """Sphinx error directive."""
+        self._push_box("ERROR")
+
     def visit_image(self, node):
         """Image directive."""
         uri = node["uri"]

--- a/tests/expected/ExampleRSTFile.md
+++ b/tests/expected/ExampleRSTFile.md
@@ -59,6 +59,18 @@ This is an important message.
 #### HINT
 This is a hint message.
 
+#### TIP
+This is a tip message.
+
+#### CAUTION
+This is a caution message.
+
+#### DANGER
+This is a danger message.
+
+#### ERROR
+This is an error message.
+
 Italics are rarely used. Text surrounded by single asterisks is rendered in
 *italics*.
 

--- a/tests/source/ExampleRSTFile.rst
+++ b/tests/source/ExampleRSTFile.rst
@@ -60,6 +60,18 @@ own line number for commenting in reviews.
 .. hint::
    This is a hint message.
 
+.. tip::
+   This is a tip message.
+
+.. caution::
+   This is a caution message.
+
+.. danger::
+   This is a danger message.
+
+.. error::
+   This is an error message.
+
 Italics are rarely used. Text surrounded by single asterisks is rendered in
 *italics*.
 


### PR DESCRIPTION
See commit message for the rationale and approach.

## Test plan

- [x] `make lint` clean (pylint 10.00/10).
- [x] `make test` — pytest 13/13 passing, 98% coverage.
- [x] `make test-diff` — `ExampleRSTFile.md` clean. (Other files diff due to a local intersphinx/SSL issue fetching docs.python.org's inventory; identical diffs are present on stock `main`, not introduced by this change.)