### PR TITLE
Render centered and caption inline instead of dropping them

### DIFF
--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -109,6 +109,8 @@ PREDEFINED_ELEMENTS: Dict[str, Union[PushContext, SKIP, None]] = dict(  # pylint
     tgroup=None,
     figure=None,
     desc_signature_line=None,
+    centered=None,  # Sphinx ".. centered::" directive — render inner text inline
+    caption=None,  # figure/code-block :caption: — emit the label text inline
 )
 
 

--- a/tests/expected/ExampleRSTFile.md
+++ b/tests/expected/ExampleRSTFile.md
@@ -16,6 +16,7 @@ This file covers the following topics.
 > 
 > * [Heading Levels](#heading-levels)
 > * [Paragraph Text and Commented Text](#paragraph-text-and-commented-text)
+> * [Centered Text](#centered-text)
 > * [Ordered and Unordered Lists](#ordered-and-unordered-lists)
 > * [Conditional Text](#conditional-text)
 > * [Notes and Warnings](#notes-and-warnings)
@@ -65,6 +66,9 @@ Italics are rarely used. Text surrounded by single asterisks is rendered in
 Monospace text is used for `code examples`. Text surrounded by double grave
 accent characters is rendered in monospace font.
 
+## Centered Text
+
+Centered text here
 <!-- comments can be added in a file by starting a line with 2 periods and a space. -->
 
 In English source files, look for comments addressed to translators from writers.
@@ -598,6 +602,16 @@ being displayed in different colors.
 </problem>
 ```
 
+The following code block uses a `:caption:` to label the file name.
+
+example.py
+```python
+print("hello")
+```
+
+The following figure uses a caption to describe the image.
+
+![Captioned figure example.](static/markdown.png)Figure caption text.
 <!-- Taken from https://github.com/openedx/edx-documentation/blob/master/en_us/links/links.rst -->
 <!-- Include this file in any file that includes a non-doc link. -->
 

--- a/tests/expected/index.md
+++ b/tests/expected/index.md
@@ -7,6 +7,7 @@
         * [Heading 5](ExampleRSTFile.md#heading-5)
           * [Heading 6](ExampleRSTFile.md#heading-6)
   * [Paragraph Text and Commented Text](ExampleRSTFile.md#paragraph-text-and-commented-text)
+  * [Centered Text](ExampleRSTFile.md#centered-text)
   * [Ordered and Unordered Lists](ExampleRSTFile.md#ordered-and-unordered-lists)
     * [Nested Lists or Content](ExampleRSTFile.md#nested-lists-or-content)
       * [Unordered List inside Ordered List](ExampleRSTFile.md#unordered-list-inside-ordered-list)

--- a/tests/source/ExampleRSTFile.rst
+++ b/tests/source/ExampleRSTFile.rst
@@ -66,6 +66,12 @@ Italics are rarely used. Text surrounded by single asterisks is rendered in
 Monospace text is used for ``code examples``. Text surrounded by double grave
 accent characters is rendered in monospace font.
 
+*****************
+Centered Text
+*****************
+
+.. centered:: Centered text here
+
 .. comments can be added in a file by starting a line with 2 periods and a space.
 
 In English source files, look for comments addressed to translators from writers.
@@ -777,5 +783,19 @@ being displayed in different colors.
         <p>PLACEHOLDER: Detailed explanation of solution</p>
       </solution>
     </problem>
+
+The following code block uses a ``:caption:`` to label the file name.
+
+.. code-block:: python
+   :caption: example.py
+
+   print("hello")
+
+The following figure uses a caption to describe the image.
+
+.. figure:: /static/markdown.png
+   :alt: Captioned figure example.
+
+   Figure caption text.
 
 .. include:: links.rst


### PR DESCRIPTION
See commit message for the rationale and approach.

## Notes for reviewers

The current rendering is intentionally minimal — it just preserves the text. Caption text is concatenated to the image / appears as a paragraph above the code fence rather than being styled as a label. A future change could give `caption` a richer handler (e.g., bold, italic, or a separator); this PR scopes itself to ending the silent data loss.

## Test plan

- [x] `make lint` clean (pylint 10.00/10).
- [x] `make test` — pytest 13/13 passing, 98% coverage.
- [x] `make test-diff` — `ExampleRSTFile.md` and `index.md` clean. (Identical pre-existing intersphinx-network diffs on other files are present on stock `main`.)