### PR TITLE
Add sphinx-design PassthroughTextElement support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ test-diff:
 
 	@echo "Verifies outputs..."
 	@diff --recursive --color=always --side-by-side --text --suppress-common-lines \
+			--exclude="_sphinx_design_static" \
 			"$(BUILD_DIR)/markdown" "$(EXPECTED_DIR)"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = ">=3.7"
 dev = [
     "sphinx>=9.0.4", # For development, we need a higher version for the tests' outputs to be identical.
     "bumpver", "black", "isort", "flake8", "pylint", "pip-tools", "pytest", "pytest-cov", "coveralls",
-    "sphinxcontrib-plantuml", "sphinxcontrib.httpdomain",
+    "sphinxcontrib-plantuml", "sphinxcontrib.httpdomain", "sphinx-design",
 ]
 
 [project.urls]

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -94,6 +94,7 @@ PREDEFINED_ELEMENTS: Dict[str, Union[PushContext, SKIP, None]] = dict(  # pylint
     glossary=None,
     field_list_item=None,
     mpl_hint=None,
+    PassthroughTextElement=None,  # sphinx-design: transparent wrapper around inline refs
     pending_xref=None,
     compound=None,
     desc_addname=None,  # module pre-roll for class/method

--- a/tests/expected/index.md
+++ b/tests/expected/index.md
@@ -73,3 +73,4 @@
   * [Section for second glossary](glossaries.md#section-for-second-glossary)
   * [Section for third glossary](glossaries.md#section-for-third-glossary)
 * [Auto Module](auto-module.md)
+* [Sphinx Design](sphinx_design.md)

--- a/tests/expected/sphinx_design.md
+++ b/tests/expected/sphinx_design.md
@@ -1,0 +1,7 @@
+# Sphinx Design
+
+A card title
+
+Body text.
+
+[https://example.com](https://example.com)

--- a/tests/source/conf.py
+++ b/tests/source/conf.py
@@ -18,6 +18,7 @@ extensions = [
     "sphinx.ext.intersphinx",  # Link to other project's documentation (see mapping below)
     "sphinx_markdown_builder",
     "sphinxcontrib.httpdomain",
+    "sphinx_design",
 ]
 
 

--- a/tests/source/index.rst
+++ b/tests/source/index.rst
@@ -13,3 +13,4 @@ Main Test File
    empty.rst
    glossaries.rst
    auto-module.rst
+   sphinx_design.rst

--- a/tests/source/sphinx_design.rst
+++ b/tests/source/sphinx_design.rst
@@ -1,0 +1,7 @@
+Sphinx Design
+=============
+
+.. card:: A card title
+   :link: https://example.com
+
+   Body text.


### PR DESCRIPTION
See commit message for the rationale and approach. [`PassthroughTextElement` is defined here](https://github.com/executablebooks/sphinx-design/blob/main/sphinx_design/shared.py).

## Test plan

- [x] `make lint` clean (pylint 10.00/10).
- [x] `make test` — pytest 13/13 passing, 98% coverage.
- [x] `make test-diff` — `sphinx_design.md`, `index.md`, and `_sphinx_design_static` all clean post-changes. (Identical pre-existing intersphinx-network diffs on other files are present on stock `main`.)