### PR TITLE
Fix: Preserve newlines in code blocks with github flavor

### DIFF
--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -346,7 +346,7 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
     def visit_Text(self, node):  # pylint: disable=invalid-name
         text = node.astext().replace("\r", "")
         # Replace line breaks with spaces to create single-line paragraphs
-        if self.config.markdown_flavor == "github":
+        if self.config.markdown_flavor == "github" and self.status.escape_text:
             text = text.replace("\n", " ")
         if self.status.escape_text:
             text = escape_markdown_chars(text)

--- a/tests/expected/blocks.md
+++ b/tests/expected/blocks.md
@@ -19,6 +19,15 @@ $$
 this is a Doctest block.
 ```
 
+## Multi-line Code Block
+
+```console
+usage: command [-h] [--option1 VALUE1]
+               [--option2 VALUE2]
+               [--option3 VALUE3]
+               argument
+```
+
 # Line Block
 
 text

--- a/tests/expected/index.md
+++ b/tests/expected/index.md
@@ -60,6 +60,7 @@
 * [Indices and tables](auto-summery.md#indices-and-tables)
 * [Math Example](blocks.md)
 * [Code Example](blocks.md#code-example)
+  * [Multi-line Code Block](blocks.md#multi-line-code-block)
 * [Line Block](blocks.md#line-block)
   * [Other text](blocks.md#other-text)
   * [Referencing terms from a glossary](blocks.md#referencing-terms-from-a-glossary)

--- a/tests/expected/overrides-auto-summery.md
+++ b/tests/expected/overrides-auto-summery.md
@@ -3,7 +3,10 @@
 <meta name="version" content="0.6.10"/>
 
 <!-- Taken from https://github.com/FabianNiehaus/sphinx-markdown-builder-toctree-test -->
-<!-- Sphinx-Markdown-Builder TocTree Test documentation master file, created by sphinx-quickstart on Thu Sep  3 12:25:35 2020. You can adapt this file completely to your liking, but it should at least contain the root `toctree` directive. -->
+<!-- Sphinx-Markdown-Builder TocTree Test documentation master file, created by
+sphinx-quickstart on Thu Sep  3 12:25:35 2020.
+You can adapt this file completely to your liking, but it should at least
+contain the root `toctree` directive. -->
 
 <a id="welcome-to-sphinx-markdown-builder-toctree-test-s-documentation"></a>
 

--- a/tests/source/blocks.rst
+++ b/tests/source/blocks.rst
@@ -23,6 +23,16 @@ Code Example
 >>> print("this is a Doctest block.")
 this is a Doctest block.
 
+Multi-line Code Block
+---------------------
+
+.. code-block:: console
+
+   usage: command [-h] [--option1 VALUE1]
+                  [--option2 VALUE2]
+                  [--option3 VALUE3]
+                  argument
+
 
 ==========
 Line Block


### PR DESCRIPTION
## Summary

Fixes a bug where `markdown_flavor = "github"` unconditionally collapses all newlines into spaces, breaking multi-line content in code blocks, doctest blocks, math blocks, and comments.

## Problem

Commit 7c4daaf introduced a workaround for GitHub-flavored markdown treating newlines as `<br/>` in paragraphs. However, the implementation in `visit_Text()` unconditionally replaces **all** `\n` characters with spaces when `markdown_flavor == "github"`, including text inside `literal_block` nodes (fenced code blocks) where newlines are semantically required.

### Example Impact

Multi-line argparse usage text from `sphinxcontrib-autoprogram`:

**Before (broken):**
```console
usage: command [-h] [--option1 VALUE1]                  [--option2 VALUE2]                  [--option3 VALUE3]                  argument
```

**After (fixed):**
```console
usage: command [-h] [--option1 VALUE1]
               [--option2 VALUE2]
               [--option3 VALUE3]
               argument
```

## Root Cause

The `visit_Text` method in `translator.py:349` only checked `self.config.markdown_flavor` without considering whether the translator was inside a verbatim context.

The `visit_literal_block` method already pushes a status with `escape_text=False` to signal "we're inside a verbatim block", but this flag was not being checked.

## Solution

Add `and self.status.escape_text` to the condition on line 349:

```python
# Before:
if self.config.markdown_flavor == "github":
    text = text.replace("\n", " ")

# After:
if self.config.markdown_flavor == "github" and self.status.escape_text:
    text = text.replace("\n", " ")
```

This ensures newlines are only collapsed in normal prose paragraphs (where `escape_text=True`), not in code/math/comment blocks (where `escape_text=False`).