### PR TITLE
Support downloadable files in Markdown output (#57)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ test-diff:
 
 	@echo "Verifies outputs..."
 	@diff --recursive --color=always --side-by-side --text --suppress-common-lines \
+			--exclude=_downloads \
 			"$(BUILD_DIR)/markdown" "$(EXPECTED_DIR)"
 
 

--- a/sphinx_markdown_builder/builder.py
+++ b/sphinx_markdown_builder/builder.py
@@ -100,16 +100,9 @@ class MarkdownBuilder(Builder):
                 file.write(self.writer.output)
 
     def finish(self):
-        self.copy_download_files()
-
-    def copy_download_files(self):
-        for source in self.env.dlfiles:
-            source_path = os.path.join(self.srcdir, source)
-            destination = os.path.join(
-                self.outdir,
-                self.download_dir,
-                self.env.dlfiles[source][1],
-            )
+        for src_file_name, (_, dst_path) in self.env.dlfiles.items():
+            source_path = os.path.join(self.srcdir, src_file_name)
+            destination = os.path.join(self.outdir, self.download_dir, dst_path)
             ensuredir(os.path.dirname(destination))
             with io_handler(source_path):
                 shutil.copyfile(source_path, destination)

--- a/sphinx_markdown_builder/builder.py
+++ b/sphinx_markdown_builder/builder.py
@@ -3,6 +3,7 @@ Custom docutils builder for markdown.
 """
 
 import os
+import shutil
 from contextlib import contextmanager
 from typing import Set
 
@@ -44,6 +45,7 @@ class MarkdownBuilder(Builder):
     default_translator_class = MarkdownTranslator
 
     out_suffix = ".md"
+    download_dir = "_downloads"
 
     def __init__(self, app: Sphinx, env: BuildEnvironment = None):
         super().__init__(app, env)
@@ -96,3 +98,18 @@ class MarkdownBuilder(Builder):
         with io_handler(out_filename):
             with open(out_filename, "w", encoding="utf-8") as file:
                 file.write(self.writer.output)
+
+    def finish(self):
+        self.copy_download_files()
+
+    def copy_download_files(self):
+        for source in self.env.dlfiles:
+            source_path = os.path.join(self.srcdir, source)
+            destination = os.path.join(
+                self.outdir,
+                self.download_dir,
+                self.env.dlfiles[source][1],
+            )
+            ensuredir(os.path.dirname(destination))
+            with io_handler(source_path):
+                shutil.copyfile(source_path, destination)

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -567,14 +567,19 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
 
     @pushing_context
     def visit_download_reference(self, node):
+        # Sphinx sets `refuri` for external targets; preserve those URLs verbatim.
         if "refuri" in node:
             target = node["refuri"]
+        # For readable internal targets, `filename` is the registered, hashed
+        # destination. Link to the copied file relative to the current output page.
         elif "filename" in node:
             target = relative_uri(
                 self.builder.get_target_uri(self.builder.current_doc_name),
                 posixpath.join(self.builder.download_dir, node["filename"]),
             )
             target = self._adjust_url(target)
+        # If Sphinx could not register the internal file, only its original
+        # `reftarget` remains; retain the previous URL-adjustment fallback.
         else:
             target = self._adjust_url(node.get("reftarget", ""))
         self._push_context(WrappedContext("[", f"]({target})"))

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 from docutils import languages, nodes
 from sphinx.util.docutils import SphinxTranslator
+from sphinx.util.osutil import relative_uri
 
 from sphinx_markdown_builder.contexts import (
     CommaSeparatedContext,
@@ -566,8 +567,17 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
 
     @pushing_context
     def visit_download_reference(self, node):
-        reftarget = self._adjust_url(node.get("reftarget", ""))
-        self._push_context(WrappedContext("[", f"]({reftarget})"))
+        if "refuri" in node:
+            target = node["refuri"]
+        elif "filename" in node:
+            target = relative_uri(
+                self.builder.get_target_uri(self.builder.current_doc_name),
+                posixpath.join(self.builder.download_dir, node["filename"]),
+            )
+            target = self._adjust_url(target)
+        else:
+            target = self._adjust_url(node.get("reftarget", ""))
+        self._push_context(WrappedContext("[", f"]({target})"))
 
     def _add_anchor(self, anchor: str):
         content = f'<a id="{escape_html_quote(anchor)}"></a>'

--- a/tests/expected/image-target.md
+++ b/tests/expected/image-target.md
@@ -2,6 +2,6 @@
 
 [![image](static/markdown.png)](https://github.com/liran-funaro/sphinx-markdown-builder)
 
-Download [`this example image`](/static/markdown.png).
+Download [`this example image`](_downloads/26598844018f8755cf64dbce62c832dd/markdown.png).
 
 ![image](static/markdown.png)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -130,3 +130,44 @@ def test_custom_file_suffix():
 
     # Clean up
     _rm_build_path(build_path)
+
+
+def test_download_references(tmp_path: Path):
+    """Test that download references use and copy Sphinx's collected files."""
+    source_path = tmp_path / "source"
+    nested_path = source_path / "guide"
+    assets_path = source_path / "assets"
+    output_path = tmp_path / "output"
+    nested_path.mkdir(parents=True)
+    assets_path.mkdir()
+
+    (source_path / "conf.py").write_text(
+        'extensions = ["sphinx_markdown_builder"]\nroot_doc = "index"\n',
+        encoding="utf-8",
+    )
+    (source_path / "index.rst").write_text(
+        ".. toctree::\n\n   guide/downloads\n",
+        encoding="utf-8",
+    )
+    (nested_path / "downloads.rst").write_text(
+        "Downloads\n"
+        "=========\n\n"
+        "Download :download:`sample <../assets/sample.pdf>`.\n\n"
+        "Visit :download:`external <https://example.com/sample.pdf>`.\n",
+        encoding="utf-8",
+    )
+    sample_contents = b"sample download contents"
+    (assets_path / "sample.pdf").write_bytes(sample_contents)
+
+    ret_code = main(["-b", "markdown", str(source_path), str(output_path)])
+    assert ret_code == 0
+
+    downloads = list((output_path / "_downloads").glob("*/sample.pdf"))
+    assert len(downloads) == 1
+    assert downloads[0].read_bytes() == sample_contents
+
+    markdown = (output_path / "guide" / "downloads.md").read_text(encoding="utf-8")
+    download_uri = downloads[0].relative_to(output_path).as_posix()
+    assert f"](../{download_uri})" in markdown
+    assert "](../assets/sample.pdf)" not in markdown
+    assert "](https://example.com/sample.pdf)" in markdown


### PR DESCRIPTION
Closes #57 

Files like PDFs that get downloaded are currently broken. The builder references them relative to the source file, but never actually copies the files into the output.

Other builders like the html and dirhtml ones copy all downloadable files to a special `_downloads` directory and then links to that relative to the output location of the page. This PR updates this builder to follow this same behavior.

Verified with a new test and also ran all tests locally.