### PR TITLE
Markdown Support for Additional Docutils Nodes

### DIFF
--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -26,7 +26,7 @@ https://github.com/docutils/docutils/blob/master/docutils/docutils/writers/html5
 import dataclasses
 import posixpath
 import re
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
 from docutils import languages, nodes
 from sphinx.util.docutils import SphinxTranslator
@@ -61,6 +61,9 @@ VISIT_DEPART_PATTERN = re.compile("(visit|depart)_(.+)")
 SKIP = UniqueString("skip")
 
 DOC_INFO_FIELDS = "author", "contact", "copyright", "date", "organization", "revision", "status", "version"
+
+# Abbreviations are rendered as footnotes. This prefix keeps their labels distinct from any other footnote.
+ABBREVIATION_LABEL_PREFIX = "abbr-"
 
 # Defines context items, skip, or None (keep processing sub-tree).
 PREDEFINED_ELEMENTS: Dict[str, Union[PushContext, PushBox, UniqueString, None]] = (
@@ -158,6 +161,8 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
         self.language = languages.get_language(self.settings.language_code, document.reporter)
         # Warn only once per writer about unsupported elements
         self._warned = set()
+        # Abbreviation (text, explanation) pairs, mapped to their footnote index, by order of appearance
+        self._abbreviations: Dict[Tuple[str, str], int] = {}
 
         # FIFO Sub context allow us to handle unique cases when post-processing is required
         self._ctx_queue: List[SubContext] = [SubContext()]
@@ -222,8 +227,17 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
         ctx = SubContext()
         for sub_ctx in (self._doc_info, self._ctx_queue[0]):
             ctx.add(sub_ctx.make().strip(), prefix_eol=2, suffix_eol=1)
+        ctx.add(self._make_abbreviation_footnotes(), prefix_eol=2, suffix_eol=1)
         ctx.force_eol(1)
         return ctx.make()
+
+    def _make_abbreviation_footnotes(self) -> str:
+        """Render the footnote definitions of the abbreviations found in the document."""
+        return "\n".join(
+            f"[^{ABBREVIATION_LABEL_PREFIX}{index}]: "
+            f"**{escape_markdown_chars(text)}**: {escape_markdown_chars(explanation)}"
+            for (text, explanation), index in self._abbreviations.items()
+        )
 
     def add(self, value: str, prefix_eol: int = 0, suffix_eol: int = 0):
         """See `SubContext.add()`"""
@@ -343,6 +357,22 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
     def visit_caption(self, _node):
         """Figure caption."""
         self._push_context(WrappedContext("*", params=SubContextParams(2, 2)))
+
+    def depart_abbreviation(self, node):
+        """Abbreviation role, e.g., :abbr:`LLM (Large Language Model)`.
+
+        Markdown has no equivalent of the HTML `title` attribute, so the explanation is moved to a footnote:
+        `LLM[^abbr-1]`, with `[^abbr-1]: **LLM**: Large Language Model` at the end of the document.
+        Repeating abbreviations share a single footnote.
+        An abbreviation without an explanation is left as-is.
+        """
+        explanation = node.get("explanation")
+        if not explanation:
+            return
+
+        key = (node.astext(), explanation)
+        index = self._abbreviations.setdefault(key, len(self._abbreviations) + 1)
+        self.add(f"[^{ABBREVIATION_LABEL_PREFIX}{index}]")
 
     # noinspection PyPep8Naming
     def visit_Text(self, node):  # pylint: disable=invalid-name

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -125,6 +125,7 @@ PREDEFINED_ELEMENTS: Dict[str, Union[PushContext, PushBox, UniqueString, None]] 
         colspec=None,
         tgroup=None,
         figure=None,
+        legend=None,
         desc_signature_line=None,
     )
 )
@@ -337,6 +338,11 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
         # We don't need to add EOL before/after the image.
         # It will be handled by the visit/depart handlers of the paragraph.
         self.add(f"![{alt}]({uri})")
+
+    @pushing_context
+    def visit_caption(self, _node):
+        """Figure caption."""
+        self._push_context(WrappedContext("*", params=SubContextParams(2, 2)))
 
     # noinspection PyPep8Naming
     def visit_Text(self, node):  # pylint: disable=invalid-name

--- a/tests/expected/ExampleRSTFile.md
+++ b/tests/expected/ExampleRSTFile.md
@@ -86,6 +86,11 @@ own line number for commenting in reviews.
 > 
 > Sidebar body.
 
+A sentence with an LLM[^abbr-1] in the middle.
+Repeating an LLM[^abbr-1] reuses the same footnote,
+while an ANN[^abbr-2] gets a footnote of its own.
+A bare RST has no explanation to spell out.
+
 Italics are rarely used. Text surrounded by single asterisks is rendered in
 *italics*.
 
@@ -645,3 +650,6 @@ being displayed in different colors.
 <!-- Browsers -->
 <!-- Peer Instruction -->
 <!-- Video Catalog -->
+
+[^abbr-1]: **LLM**: Large Language Model
+[^abbr-2]: **ANN**: Artificial Neural Network

--- a/tests/expected/ExampleRSTFile.md
+++ b/tests/expected/ExampleRSTFile.md
@@ -443,6 +443,12 @@ Image links can include optional specifications such as height, width, or
 scale. Alternative text for screen readers is required for each image. Provide
 text that is useful to someone who might not be able to see the image.
 
+![Markdown logo](static/markdown.png)
+
+*Figure caption text.*
+
+Figure legend paragraph.
+
 <a id="examples-of-tables"></a>
 
 ## Tables

--- a/tests/source/ExampleRSTFile.rst
+++ b/tests/source/ExampleRSTFile.rst
@@ -84,6 +84,10 @@ own line number for commenting in reviews.
 
    Sidebar body.
 
+A sentence with an :abbr:`LLM (Large Language Model)` in the middle.
+Repeating an :abbr:`LLM (Large Language Model)` reuses the same footnote,
+while an :abbr:`ANN (Artificial Neural Network)` gets a footnote of its own.
+A bare :abbr:`RST` has no explanation to spell out.
 
 Italics are rarely used. Text surrounded by single asterisks is rendered in
 *italics*.

--- a/tests/source/ExampleRSTFile.rst
+++ b/tests/source/ExampleRSTFile.rst
@@ -542,6 +542,13 @@ Image links can include optional specifications such as height, width, or
 scale. Alternative text for screen readers is required for each image. Provide
 text that is useful to someone who might not be able to see the image.
 
+.. figure:: /static/markdown.png
+   :alt: Markdown logo
+
+   Figure caption text.
+
+   Figure legend paragraph.
+
 
 .. _Examples of Tables:
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -77,3 +77,18 @@ def test_problematic():
         mt.dispatch_visit(node)
     mt.add("suffix")
     assert mt.astext() == "prefix\n\n```\ntext\n```\n\nsuffix\n"
+
+
+def test_abbreviation_footnotes():
+    mt = make_mock()
+    llm = docutils.nodes.abbreviation("", "LLM", explanation="Large Language Model")
+    rst = docutils.nodes.abbreviation("", "RST")
+
+    # The same abbreviation is expected to share a single footnote,
+    # while an abbreviation without an explanation is expected to be left as-is.
+    for node in (llm, llm, rst):
+        mt.dispatch_visit(node)
+        mt.add(node.astext())
+        mt.dispatch_departure(node)
+
+    assert mt.astext() == "LLM[^abbr-1]LLM[^abbr-1]RST\n\n[^abbr-1]: **LLM**: Large Language Model\n"


### PR DESCRIPTION
## Summary

Add native Markdown rendering for several Docutils node types that were
previously unsupported. Unsupported nodes produced an `unknown node type`
warning and could cause their content to be silently omitted from the generated
Markdown.

This adds support for:

* Figure captions, rendered as emphasized text
* Figure legends, rendered as normal body content
* Abbreviations, with their explanation moved to a footnote

Generic admonitions and sidebars have been dropped from this PR after rebasing
on `main` — #64 covers both, so no additional handling is needed for those.

Abbreviations follow the footnote option raised in review rather than an HTML
`<abbr>` tag. Repeating abbreviations share a single footnote, and an
abbreviation with no explanation is left untouched:

```markdown
A sentence with an LLM[^abbr-1] in the middle.
Repeating an LLM[^abbr-1] reuses the same footnote.

[^abbr-1]: **LLM**: Large Language Model
```

Closes [#61](https://github.com/liran-funaro/sphinx-markdown-builder/pull/61).