### PR TITLE
refactor: replace admonition visit methods with PREDEFINED_ELEMENTS entries

### DIFF
--- a/sphinx_markdown_builder/contexts.py
+++ b/sphinx_markdown_builder/contexts.py
@@ -413,3 +413,9 @@ DOC_INFO_CONTEXT = PushContext(
     MetaContext,
     translator=lambda _node, elem: {"name": f"{elem}: "},
 )
+
+
+@dataclass(frozen=True)
+class PushBox:
+    title: str
+    heading: str | None = None

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -191,8 +191,8 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
             ctx.add(last_ctx.make(), last_ctx.params.prefix_eol, last_ctx.params.suffix_eol)
 
     def _push_box(self, title: str, heading: str | None = None):
-        self.add(f">[!{title}]")
-        self._push_context(IndentContext(prefix=">", empty=True, params=SubContextParams(1, 2)))
+        self.add(f"> [!{title}]")
+        self._push_context(IndentContext(prefix="> ", empty=True, params=SubContextParams(1, 2)))
         self._push_status(section_level=3)
         if heading is not None:
             self.add(f"### {heading}")

--- a/sphinx_markdown_builder/translator.py
+++ b/sphinx_markdown_builder/translator.py
@@ -40,6 +40,7 @@ from sphinx_markdown_builder.contexts import (
     ITALIC_CONTEXT,
     ListMarker,
     MetaContext,
+    PushBox,
     PushContext,
     STRONG_CONTEXT,
     SubContext,
@@ -62,54 +63,70 @@ SKIP = UniqueString("skip")
 DOC_INFO_FIELDS = "author", "contact", "copyright", "date", "organization", "revision", "status", "version"
 
 # Defines context items, skip, or None (keep processing sub-tree).
-PREDEFINED_ELEMENTS: Dict[str, Union[PushContext, SKIP, None]] = dict(  # pylint: disable=use-dict-literal
-    # Doctree elements for which Markdown element is <prefix><content><suffix>
-    emphasis=ITALIC_CONTEXT,
-    strong=STRONG_CONTEXT,
-    subscript=SUBSCRIPT_CONTEXT,
-    superscript=SUBSCRIPT_CONTEXT,
-    desc_annotation=ITALIC_CONTEXT,
-    literal_strong=STRONG_CONTEXT,
-    literal_emphasis=ITALIC_CONTEXT,
-    field_name=PushContext(WrappedContext, "**", ":**"),  # e.g 'returns', 'parameters'
-    # Doc info elements
-    docinfo=DOC_INFO_CONTEXT,
-    docinfo_item=DOC_INFO_CONTEXT,
-    **dict.fromkeys(DOC_INFO_FIELDS, DOC_INFO_CONTEXT),
-    authors=None,  # not used: visit_author is called anyway for each author.
-    # Doctree elements to skip subtree
-    autosummary_toc=SKIP,
-    nbplot_epilogue=SKIP,
-    nbplot_not_rendered=SKIP,
-    nbplot_container=SKIP,
-    code_links=SKIP,
-    index=SKIP,
-    substitution_definition=SKIP,  # the doctree already contains the text with substitutions applied.
-    runrole_reference=SKIP,
-    # Doctree elements to ignore
-    document=None,
-    container=None,
-    inline=None,
-    definition_list=None,
-    definition_list_item=None,
-    glossary=None,
-    field_list_item=None,
-    mpl_hint=None,
-    pending_xref=None,
-    compound=None,
-    desc_addname=None,  # module pre-roll for class/method
-    desc_content=None,  # the description of the class/method
-    desc_name=None,  # name of the class/method
-    title_reference=None,
-    autosummary_table=None,  # Sphinx autosummary
-    # See https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html.
-    # Ignored table elements
-    raw=None,
-    tabular_col_spec=None,
-    colspec=None,
-    tgroup=None,
-    figure=None,
-    desc_signature_line=None,
+PREDEFINED_ELEMENTS: Dict[str, Union[PushContext, PushBox, UniqueString, None]] = (
+    dict(  # pylint: disable=use-dict-literal
+        # Doctree elements for which Markdown element is <prefix><content><suffix>
+        emphasis=ITALIC_CONTEXT,
+        strong=STRONG_CONTEXT,
+        subscript=SUBSCRIPT_CONTEXT,
+        superscript=SUBSCRIPT_CONTEXT,
+        desc_annotation=ITALIC_CONTEXT,
+        literal_strong=STRONG_CONTEXT,
+        literal_emphasis=ITALIC_CONTEXT,
+        field_name=PushContext(WrappedContext, "**", ":**"),  # e.g 'returns', 'parameters'
+        # Doc info elements
+        docinfo=DOC_INFO_CONTEXT,
+        docinfo_item=DOC_INFO_CONTEXT,
+        **dict.fromkeys(DOC_INFO_FIELDS, DOC_INFO_CONTEXT),
+        authors=None,  # not used: visit_author is called anyway for each author.
+        # Admonitions
+        important=PushBox("IMPORTANT"),
+        warning=PushBox("WARNING"),
+        note=PushBox("NOTE"),
+        seealso=PushBox("NOTE", "See also"),
+        attention=PushBox("IMPORTANT"),
+        hint=PushBox("TIP"),
+        tip=PushBox("TIP"),
+        caution=PushBox("CAUTION"),
+        danger=PushBox("CAUTION"),
+        error=PushBox("CAUTION"),
+        admonition=PushBox("NOTE"),
+        sidebar=PushBox("TIP"),
+        versionmodified=PushBox("WARNING"),  # “versionadded”, “versionchanged” and “deprecated” directives.
+        # Doctree elements to skip subtree
+        autosummary_toc=SKIP,
+        nbplot_epilogue=SKIP,
+        nbplot_not_rendered=SKIP,
+        nbplot_container=SKIP,
+        code_links=SKIP,
+        index=SKIP,
+        substitution_definition=SKIP,  # the doctree already contains the text with substitutions applied.
+        runrole_reference=SKIP,
+        # Doctree elements to ignore
+        document=None,
+        container=None,
+        inline=None,
+        definition_list=None,
+        definition_list_item=None,
+        glossary=None,
+        field_list_item=None,
+        mpl_hint=None,
+        pending_xref=None,
+        compound=None,
+        desc_addname=None,  # module pre-roll for class/method
+        desc_content=None,  # the description of the class/method
+        desc_name=None,  # name of the class/method
+        title_reference=None,
+        autosummary_table=None,  # Sphinx autosummary
+        # See https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html.
+        # Ignored table elements
+        raw=None,
+        tabular_col_spec=None,
+        colspec=None,
+        tgroup=None,
+        figure=None,
+        desc_signature_line=None,
+    )
 )
 
 
@@ -173,9 +190,12 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
             ctx = self.ctx if last_ctx.params.target == "body" else self._doc_info
             ctx.add(last_ctx.make(), last_ctx.params.prefix_eol, last_ctx.params.suffix_eol)
 
-    def _push_box(self, title: str):
-        self.add(f"#### {title}", prefix_eol=2)
-        self._push_context(SubContext(SubContextParams(1, 2)))
+    def _push_box(self, title: str, heading: str | None = None):
+        self.add(f">[!{title}]")
+        self._push_context(IndentContext(prefix=">", empty=True, params=SubContextParams(1, 2)))
+        self._push_status(section_level=3)
+        if heading is not None:
+            self.add(f"### {heading}")
 
     @property
     def status(self) -> ContextStatus:
@@ -242,7 +262,7 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
                 return predefined_method
             raise ex
 
-    def _find_predefined_action(self, state: str, element: str):
+    def _find_predefined_action(self, state: str, element: str):  # pylint: disable=too-many-return-statements
         action = PREDEFINED_ELEMENTS.get(element, "__undefined__")
         if action is None:
             return self._pass
@@ -252,6 +272,10 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
             if state == "visit":
                 return lambda node: self._push_context(action.create(node, element))
             return self._pop_context
+        if isinstance(action, PushBox):
+            if state == "visit":
+                return lambda _node: self._push_box(action.title, action.heading)
+            return self._pop_context_and_status
         return None
 
     def _find_pushing_method(self, state: str, element: str):
@@ -305,55 +329,6 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
     ################################################################################
     # visit/depart handlers
     ################################################################################
-
-    @pushing_context
-    def visit_important(self, _node):
-        """Sphinx important directive."""
-        self._push_box("IMPORTANT")
-
-    @pushing_context
-    def visit_warning(self, _node):
-        """Sphinx warning directive."""
-        self._push_box("WARNING")
-
-    @pushing_context
-    def visit_note(self, _node):
-        """Sphinx note directive."""
-        self._push_box("NOTE")
-
-    @pushing_context
-    def visit_seealso(self, _node):
-        """Sphinx see also directive."""
-        self._push_box("SEE ALSO")
-
-    @pushing_context
-    def visit_attention(self, _node):
-        self._push_box("ATTENTION")
-
-    @pushing_context
-    def visit_hint(self, _node):
-        """Sphinx hint directive."""
-        self._push_box("HINT")
-
-    @pushing_context
-    def visit_tip(self, _node):
-        """Sphinx tip directive."""
-        self._push_box("TIP")
-
-    @pushing_context
-    def visit_caution(self, _node):
-        """Sphinx caution directive."""
-        self._push_box("CAUTION")
-
-    @pushing_context
-    def visit_danger(self, _node):
-        """Sphinx danger directive."""
-        self._push_box("DANGER")
-
-    @pushing_context
-    def visit_error(self, _node):
-        """Sphinx error directive."""
-        self._push_box("ERROR")
 
     def visit_image(self, node):
         """Image directive."""
@@ -711,16 +686,6 @@ class MarkdownTranslator(SphinxTranslator):  # pylint: disable=too-many-public-m
     @pushing_context
     def visit_field_body(self, _node):
         self._push_context(SubContext(SubContextParams(1, 1)))
-
-    @pushing_context
-    def visit_versionmodified(self, node):
-        """
-        Node for version change entries.
-        Currently used for “versionadded”, “versionchanged” and “deprecated” directives.
-        Type will hold something like 'deprecated'
-        """
-        node_type = node.attributes["type"].capitalize()
-        self._push_box(node_type)
 
     ################################################################################
     # tables

--- a/tests/expected/ExampleRSTFile.md
+++ b/tests/expected/ExampleRSTFile.md
@@ -43,33 +43,48 @@ This is an example of regular text in paragraph form. There are no indents. As
 a best practice, break lines at about 80 characters, so that each line has its
 own line number for commenting in reviews.
 
-#### WARNING
-Throughout text and code examples, make sure double quotation
-marks and apostrophes are straight (”) or (‘), not curly quotatation marks
-and apostrophes, which might be introduced when text is cut and pasted from
-other sources or editors.
+>[!WARNING]
+>Throughout text and code examples, make sure double quotation
+>marks and apostrophes are straight (”) or (‘), not curly quotatation marks
+>and apostrophes, which might be introduced when text is cut and pasted from
+>other sources or editors.
 
-#### ATTENTION
-Boldface is used for labels that are visible in the user interface. The UI
-text is surrounded by double asterisks. For example, **bold**.
+>[!IMPORTANT]
+>Boldface is used for labels that are visible in the user interface. The UI
+>text is surrounded by double asterisks. For example, **bold**.
 
-#### IMPORTANT
-This is an important message.
+>[!IMPORTANT]
+>This is an important message.
 
-#### HINT
-This is a hint message.
+>[!TIP]
+>This is a hint message.
 
-#### TIP
-This is a tip message.
+>[!TIP]
+>This is a tip message.
 
-#### CAUTION
-This is a caution message.
+>[!CAUTION]
+>This is a caution message.
 
-#### DANGER
-This is a danger message.
+>[!CAUTION]
+>This is a danger message.
 
-#### ERROR
-This is an error message.
+>[!CAUTION]
+>This is an error message.
+
+>[!NOTE]
+>### See also
+>
+>Another place.
+
+>[!NOTE]
+>### Custom Admonition Title
+>
+>Generic admonition body.
+
+>[!TIP]
+>### Sidebar Title
+>
+>Sidebar body.
 
 Italics are rarely used. Text surrounded by single asterisks is rendered in
 *italics*.
@@ -93,9 +108,9 @@ Use hash symbols for ordered lists.
 2. Find the **Course Advertised Start Date** policy key.
 3. Enter the value you want to display.
 
-#### NOTE
-Ordered lists usually use numerals. Nested ordered lists (ordered lists inside
-other ordered lists) use letters.
+>[!NOTE]
+>Ordered lists usually use numerals. Nested ordered lists (ordered lists inside
+>other ordered lists) use letters.
 
 Use asterisks for unordered (bulleted) lists.
 
@@ -228,13 +243,13 @@ indented under the only directive.
    to the same level as the rest of the note.
 ```
 
-#### NOTE
-This is note text. If note text runs over a line, make sure the lines wrap
-and are indented to the same level as the note tag. If formatting is
-incorrect, part of the note might not render in the HTML output.
-
-Notes can have more than one paragraph. Successive paragraphs must indent to
-the same level as the rest of the note.
+>[!NOTE]
+>This is note text. If note text runs over a line, make sure the lines wrap
+>and are indented to the same level as the note tag. If formatting is
+>incorrect, part of the note might not render in the HTML output.
+>
+>Notes can have more than one paragraph. Successive paragraphs must indent to
+>the same level as the rest of the note.
 
 ```default
 .. warning::
@@ -242,9 +257,9 @@ the same level as the rest of the note.
    must be broken and indented under the warning tag.
 ```
 
-#### WARNING
-Warnings are formatted in the same way as notes. In the same way, lines must
-be broken and indented under the warning tag.
+>[!WARNING]
+>Warnings are formatted in the same way as notes. In the same way, lines must
+>be broken and indented under the warning tag.
 
 ## Cross-References
 
@@ -306,9 +321,9 @@ syntax, as in the following example.
 
 If you want to, you can use [keyboard shortcuts](#sfd-sn-keyboard-shortcuts) to create, edit, and view notes.
 
-#### NOTE
-Do not include a space between the last word of the link text and the opening
-angle bracket for the anchor text.
+>[!NOTE]
+>Do not include a space between the last word of the link text and the opening
+>angle bracket for the anchor text.
 
 In this example, “keyboard shortcuts” is the link text, and “SFD SN Keyboard
 Shortcuts” is the anchor text for a section that is titled “Keyboard Shortcuts
@@ -394,10 +409,10 @@ To create an external cross-reference, follow these steps.
    .. include:: ../../links/links.rst
    ```
 
-   #### NOTE
-   The path to the links.rst file depends on the location of the file where
-   you are creating the link. For example, the path might be
-   `../../../links/links.rst` or `../links/links.rst`.
+   >[!NOTE]
+   >The path to the links.rst file depends on the location of the file where
+   >you are creating the link. For example, the path might be
+   >`../../../links/links.rst` or `../links/links.rst`.
 3. In the `edx-documentation/en_us/links/links.rst` file, add an entry for
    the anchor text and the URL of the external website, formatted as follows.
    Make sure that the anchor text in this file matches the anchor text in the

--- a/tests/expected/ExampleRSTFile.md
+++ b/tests/expected/ExampleRSTFile.md
@@ -43,48 +43,48 @@ This is an example of regular text in paragraph form. There are no indents. As
 a best practice, break lines at about 80 characters, so that each line has its
 own line number for commenting in reviews.
 
->[!WARNING]
->Throughout text and code examples, make sure double quotation
->marks and apostrophes are straight (”) or (‘), not curly quotatation marks
->and apostrophes, which might be introduced when text is cut and pasted from
->other sources or editors.
+> [!WARNING]
+> Throughout text and code examples, make sure double quotation
+> marks and apostrophes are straight (”) or (‘), not curly quotatation marks
+> and apostrophes, which might be introduced when text is cut and pasted from
+> other sources or editors.
 
->[!IMPORTANT]
->Boldface is used for labels that are visible in the user interface. The UI
->text is surrounded by double asterisks. For example, **bold**.
+> [!IMPORTANT]
+> Boldface is used for labels that are visible in the user interface. The UI
+> text is surrounded by double asterisks. For example, **bold**.
 
->[!IMPORTANT]
->This is an important message.
+> [!IMPORTANT]
+> This is an important message.
 
->[!TIP]
->This is a hint message.
+> [!TIP]
+> This is a hint message.
 
->[!TIP]
->This is a tip message.
+> [!TIP]
+> This is a tip message.
 
->[!CAUTION]
->This is a caution message.
+> [!CAUTION]
+> This is a caution message.
 
->[!CAUTION]
->This is a danger message.
+> [!CAUTION]
+> This is a danger message.
 
->[!CAUTION]
->This is an error message.
+> [!CAUTION]
+> This is an error message.
 
->[!NOTE]
->### See also
->
->Another place.
+> [!NOTE]
+> ### See also
+> 
+> Another place.
 
->[!NOTE]
->### Custom Admonition Title
->
->Generic admonition body.
+> [!NOTE]
+> ### Custom Admonition Title
+> 
+> Generic admonition body.
 
->[!TIP]
->### Sidebar Title
->
->Sidebar body.
+> [!TIP]
+> ### Sidebar Title
+> 
+> Sidebar body.
 
 Italics are rarely used. Text surrounded by single asterisks is rendered in
 *italics*.
@@ -108,9 +108,9 @@ Use hash symbols for ordered lists.
 2. Find the **Course Advertised Start Date** policy key.
 3. Enter the value you want to display.
 
->[!NOTE]
->Ordered lists usually use numerals. Nested ordered lists (ordered lists inside
->other ordered lists) use letters.
+> [!NOTE]
+> Ordered lists usually use numerals. Nested ordered lists (ordered lists inside
+> other ordered lists) use letters.
 
 Use asterisks for unordered (bulleted) lists.
 
@@ -243,13 +243,13 @@ indented under the only directive.
    to the same level as the rest of the note.
 ```
 
->[!NOTE]
->This is note text. If note text runs over a line, make sure the lines wrap
->and are indented to the same level as the note tag. If formatting is
->incorrect, part of the note might not render in the HTML output.
->
->Notes can have more than one paragraph. Successive paragraphs must indent to
->the same level as the rest of the note.
+> [!NOTE]
+> This is note text. If note text runs over a line, make sure the lines wrap
+> and are indented to the same level as the note tag. If formatting is
+> incorrect, part of the note might not render in the HTML output.
+> 
+> Notes can have more than one paragraph. Successive paragraphs must indent to
+> the same level as the rest of the note.
 
 ```default
 .. warning::
@@ -257,9 +257,9 @@ indented under the only directive.
    must be broken and indented under the warning tag.
 ```
 
->[!WARNING]
->Warnings are formatted in the same way as notes. In the same way, lines must
->be broken and indented under the warning tag.
+> [!WARNING]
+> Warnings are formatted in the same way as notes. In the same way, lines must
+> be broken and indented under the warning tag.
 
 ## Cross-References
 
@@ -321,9 +321,9 @@ syntax, as in the following example.
 
 If you want to, you can use [keyboard shortcuts](#sfd-sn-keyboard-shortcuts) to create, edit, and view notes.
 
->[!NOTE]
->Do not include a space between the last word of the link text and the opening
->angle bracket for the anchor text.
+> [!NOTE]
+> Do not include a space between the last word of the link text and the opening
+> angle bracket for the anchor text.
 
 In this example, “keyboard shortcuts” is the link text, and “SFD SN Keyboard
 Shortcuts” is the anchor text for a section that is titled “Keyboard Shortcuts
@@ -409,10 +409,10 @@ To create an external cross-reference, follow these steps.
    .. include:: ../../links/links.rst
    ```
 
-   >[!NOTE]
-   >The path to the links.rst file depends on the location of the file where
-   >you are creating the link. For example, the path might be
-   >`../../../links/links.rst` or `../links/links.rst`.
+   > [!NOTE]
+   > The path to the links.rst file depends on the location of the file where
+   > you are creating the link. For example, the path might be
+   > `../../../links/links.rst` or `../links/links.rst`.
 3. In the `edx-documentation/en_us/links/links.rst` file, add an entry for
    the anchor text and the URL of the external website, formatted as follows.
    Make sure that the anchor text in this file matches the anchor text in the

--- a/tests/expected/auto-module.md
+++ b/tests/expected/auto-module.md
@@ -30,8 +30,8 @@ Y value
 
 Some old function.
 
-#### Deprecated
-Deprecated since version 3.1: Use `other()` instead.
+>[!WARNING]
+>Deprecated since version 3.1: Use `other()` instead.
 
 ### func1(param1)
 

--- a/tests/expected/auto-module.md
+++ b/tests/expected/auto-module.md
@@ -30,8 +30,8 @@ Y value
 
 Some old function.
 
->[!WARNING]
->Deprecated since version 3.1: Use `other()` instead.
+> [!WARNING]
+> Deprecated since version 3.1: Use `other()` instead.
 
 ### func1(param1)
 

--- a/tests/expected/library/my_module.md
+++ b/tests/expected/library/my_module.md
@@ -38,8 +38,8 @@ Y value
 
 Some old function.
 
-#### Deprecated
-Deprecated since version 3.1: Use `other()` instead.
+>[!WARNING]
+>Deprecated since version 3.1: Use `other()` instead.
 
 ### func1(param1)
 

--- a/tests/expected/library/my_module.md
+++ b/tests/expected/library/my_module.md
@@ -38,8 +38,8 @@ Y value
 
 Some old function.
 
->[!WARNING]
->Deprecated since version 3.1: Use `other()` instead.
+> [!WARNING]
+> Deprecated since version 3.1: Use `other()` instead.
 
 ### func1(param1)
 

--- a/tests/expected/library/my_module.module_class.md
+++ b/tests/expected/library/my_module.module_class.md
@@ -28,7 +28,7 @@ This is a dummy function that does not do anything.
 * **Return type:**
   None
 
->[!NOTE]
->### See also
->
->[`function()`](my_module.submodule.my_class.md#my_module.submodule.my_class.SubmoduleClass.function)
+> [!NOTE]
+> ### See also
+> 
+> [`function()`](my_module.submodule.my_class.md#my_module.submodule.my_class.SubmoduleClass.function)

--- a/tests/expected/library/my_module.module_class.md
+++ b/tests/expected/library/my_module.module_class.md
@@ -28,5 +28,7 @@ This is a dummy function that does not do anything.
 * **Return type:**
   None
 
-#### SEE ALSO
-[`function()`](my_module.submodule.my_class.md#my_module.submodule.my_class.SubmoduleClass.function)
+>[!NOTE]
+>### See also
+>
+>[`function()`](my_module.submodule.my_class.md#my_module.submodule.my_class.SubmoduleClass.function)

--- a/tests/expected/overrides-auto-module.md
+++ b/tests/expected/overrides-auto-module.md
@@ -34,8 +34,8 @@ Y value
 
 Some old function.
 
-#### Deprecated
-Deprecated since version 3.1: Use `other()` instead.
+>[!WARNING]
+>Deprecated since version 3.1: Use `other()` instead.
 
 ### func1(param1: [int](https://docs.python.org/3/library/functions.html#int)) → [int](https://docs.python.org/3/library/functions.html#int)
 

--- a/tests/expected/overrides-auto-module.md
+++ b/tests/expected/overrides-auto-module.md
@@ -34,8 +34,8 @@ Y value
 
 Some old function.
 
->[!WARNING]
->Deprecated since version 3.1: Use `other()` instead.
+> [!WARNING]
+> Deprecated since version 3.1: Use `other()` instead.
 
 ### func1(param1: [int](https://docs.python.org/3/library/functions.html#int)) → [int](https://docs.python.org/3/library/functions.html#int)
 

--- a/tests/source/ExampleRSTFile.rst
+++ b/tests/source/ExampleRSTFile.rst
@@ -72,6 +72,19 @@ own line number for commenting in reviews.
 .. error::
    This is an error message.
 
+.. seealso::
+
+   Another place.
+
+.. admonition:: Custom Admonition Title
+
+   Generic admonition body.
+
+.. sidebar:: Sidebar Title
+
+   Sidebar body.
+
+
 Italics are rarely used. Text surrounded by single asterisks is rendered in
 *italics*.
 


### PR DESCRIPTION
Add PushBox dataclass to contexts.py and handle it in _find_predefined_action, allowing all admonition-type nodes (note, warning, tip, caution, etc.) to be declared declaratively in PREDEFINED_ELEMENTS instead of repetitive visit/depart method pairs.

Also switches admonition output from plain headings (#### TITLE) to GitHub-style alert blocks (>[!TYPE]), and adds heading support to _push_box for seealso, admonition, and sidebar nodes.